### PR TITLE
added: exchange fork pairs

### DIFF
--- a/_forks/2x.md
+++ b/_forks/2x.md
@@ -19,9 +19,3 @@ repo: https://github.com/bitcoin2m/BitcoinX
 #### Technical Info:
 
 - Pre-mine (coins): 200,000
-
-----
-
-<a href="{{ page.repo }}" target="_blank">Repository <i class="fa fa-external-link" aria-hidden="true"></i></a>
-
-<a href="{{ page.project_url }}" target="_blank">Project website <i class="fa fa-external-link" aria-hidden="true"></i></a>

--- a/_forks/cash.md
+++ b/_forks/cash.md
@@ -11,6 +11,19 @@ parent_chain: Clashic
 project_url: http://bitcoincash.org/
 address_format: bitcoin (bech32 in discussion)
 repo: https://github.com/Bitcoin-ABC/bitcoin-abc
+exchange_pairs:
+  - { name: 'Binance', pair: 'BCC/BTC', link: 'https://www.binance.com/trade.html?symbol=BCC_BTC' }
+  - { name: 'Bittrex', pair: 'BCC/BTC', link: 'https://bittrex.com/Market/Index?MarketName=BTC-BCC' }
+  - { name: 'Bitfinex', pair: 'BCH/BTC', link: 'https://www.bitfinex.com/t/BCH:BTC' }
+  - { name: 'Bit-Z', pair: 'BCH/BTC', link: 'https://www.bit-z.com/trade/bch_btc' }
+  - { name: 'BTCC', pair: 'BCC/BTC', link: 'https://dax.btcc.com/' }
+  - { name: 'CoinEgg', pair: 'BCH/BTC', link: 'https://www.coinegg.com/bch/' }
+  - { name: 'CoolCoin', pair: 'BCH/BTC', link: 'https://www.coolcoin.com/bch/' }
+  - { name: 'HitBTC', pair: 'BCH/BTC', link: 'https://hitbtc.com/exchange/BCH-to-BTC' }
+  - { name: 'Huobi', pair: 'BCC/BTC', link: 'https://www.huobi.pro/ko-kr/bcc_btc/exchange/' }
+  - { name: 'Kraken', pair: 'BCH/XBT', link: 'https://www.kraken.com/' }
+  - { name: 'OKEx', pair: 'BCC/BTC', link: 'https://www.okex.com/spot/trade/index.do#bcc_btc' }
+  - { name: 'Poloniex', pair: 'BCH/BTC', link: 'https://poloniex.com/exchange/#btc_bch' }
 ---
 
 >fork of what is now known as Clashic (formerly Cash) on November 13th
@@ -26,9 +39,3 @@ repo: https://github.com/Bitcoin-ABC/bitcoin-abc
 - second hard fork spec - <a href="https://github.com/Bitcoin-UAHF/spec/blob/master/nov-13-hardfork-spec.md" target="_blank"><i class="fa fa-external-link" aria-hidden="true"></i></a>
 
 - new address format proposal - <a href="https://github.com/Bitcoin-UAHF/spec/blob/master/cashaddr.md" target="_blank"> <i class="fa fa-external-link" aria-hidden="true"></i></a>
-
-----
-
-<a href="{{ page.repo }}" target="_blank">Repository <i class="fa fa-external-link" aria-hidden="true"></i></a>
-
-<a href="{{ page.project_url }}" target="_blank">Project website <i class="fa fa-external-link" aria-hidden="true"></i></a>

--- a/_forks/clashic.md
+++ b/_forks/clashic.md
@@ -20,9 +20,3 @@ repo: https://github.com/Bitcoin-Clashic/bitcoin-clashic
 #### Technical Info:
 
 - Address Format: {{ page.address_format }}
-
-----
-
-<a href="{{ page.repo }}" target="_blank">Repository <i class="fa fa-external-link" aria-hidden="true"></i></a>
-
-<a href="{{ page.project_url }}" target="_blank">Project website <i class="fa fa-external-link" aria-hidden="true"></i></a>

--- a/_forks/diamond.md
+++ b/_forks/diamond.md
@@ -11,10 +11,13 @@ parent_chain: Bitcoin
 project_url: http://btcd.io/
 address_format:
 repo:
+exchange_pairs:
+  - { name: 'Binance', pair: 'BCD/BTC', link: 'https://www.binance.com/trade.html?symbol=BCD_BTC' }
+  - { name: 'EXX', pair: 'BCD/BTC', link: 'https://www.exx.com/trade/bcd_btc' }
+  - { name: 'Huobi', pair: 'BCD/BTC', link: 'https://www.huobi.pro/ko-kr/bcd_btc/exchange/' }
+  - { name: 'OKEx', pair: 'BCD/BTC', link: 'https://www.okex.com/spot/trade/index.do#bcd_btc' }
 ---
 
 >chain state snapshotted, but code not released yet so it's hard to say whether the fork actually occurred yet
 
 {% include fork_table.html %}
-
-<a href="{{ page.project_url }}" target="_blank">Project website <i class="fa fa-external-link" aria-hidden="true"></i></a>

--- a/_forks/gold.md
+++ b/_forks/gold.md
@@ -11,6 +11,14 @@ parent_chain: Bitcoin
 project_url: https://bitcoingold.org
 address_format: btg
 repo: https://github.com/BTCGPU/BTCGPU
+exchange_pairs:
+  - { name: 'Binance', pair: 'BTG/BTC', link: 'https://www.binance.com/trade.html?symbol=BTG_BTC' }
+  - { name: 'Bitfinex', pair: 'BTG/BTC', link: 'https://www.bitfinex.com/t/BTG:BTC' }
+  - { name: 'Bittrex', pair: 'BTG/BTC', link: 'https://bittrex.com/Market/Index?MarketName=BTC-BTG' }
+  - { name: 'Exrates', pair: 'BTG/BTC', link: 'https://lk.exrates.me/dashboard?name=BTC/BTG' }
+  - { name: 'HitBTC', pair: 'BTG/BTC', link: 'https://hitbtc.com/exchange/BTG-to-BTC' }
+  - { name: 'Huobi', pair: 'BTG/BTC', link: 'https://www.huobi.pro/ko-kr/btg_btc/exchange/' }
+  - { name: 'OKEx', pair: 'BTG/BTC', link: 'https://www.okex.com/spot/trade/index.do#btg_btc' }
 ---
 
 >fork of Bitcoin after segwit
@@ -32,9 +40,3 @@ repo: https://github.com/BTCGPU/BTCGPU
 - sighash changes - <a href="https://github.com/BTCGPU/BTCGPU/pull/109/"><i class="fa fa-external-link" aria-hidden="true"></i></a>
 
 - segwit address support - <a href="https://github.com/BTCGPU/BTCGPU/issues/215"><i class="fa fa-external-link" aria-hidden="true"></i></a>
-
-----
-
-<a href="{{ page.repo }}" target="_blank">Repository <i class="fa fa-external-link" aria-hidden="true"></i></a>
-
-<a href="{{ page.project_url }}" target="_blank">Project website <i class="fa fa-external-link" aria-hidden="true"></i></a>

--- a/_forks/superbitcoin.md
+++ b/_forks/superbitcoin.md
@@ -19,7 +19,3 @@ address_format: 2m
 - Pre-mine (coins): 210,000
 
 - Address Format: {{ page.address_format }}
-
-----
-
-<a href="{{ page.project_url }}" target="_blank">Project website <i class="fa fa-external-link" aria-hidden="true"></i></a>

--- a/_layouts/coin.html
+++ b/_layouts/coin.html
@@ -11,7 +11,44 @@ layout: default
   </header>
 
   <div class="post-content" itemprop="articleBody">
+    {% if page.repo or page.project_url %}
+      <div class="mb2">
+        {% if page.repo %}
+          <a class="mr1" href="{{ page.repo }}" target="_blank">Repository
+            <i class="fa fa-external-link" aria-hidden="true"></i></a>
+        {% endif %}
+
+        {% if page.project_url %}
+          <a href="{{ page.project_url }}" target="_blank">Project website
+            <i class="fa fa-external-link" aria-hidden="true"></i></a>
+        {% endif %}
+      </div>
+    {% endif %}
+
     {{ content }}
+
+    {% if page.exchange_pairs %}
+      <hr>
+      <h4>Exchanges:</h4>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Trading Pair</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for exchange in page.exchange_pairs %}
+          <tr>
+            <td data-label="Name">{{ exchange.name }}</td>
+            <td data-label="Pair"><a href="{{ exchange.link }}" target="_blank">{{ exchange.pair }}</a></td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% endif %}
+
   </div>
 
 </article>

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -267,7 +267,7 @@
  */
 .page-content {
   padding-top: 90px;
-  padding-bottom: 120px;
+  padding-bottom: 140px;
 
   @include media-query($on-laptop) {
     padding-bottom: 200px;
@@ -307,7 +307,7 @@
  * Posts
  */
 .post-header {
-  margin-bottom: $spacing-unit;
+  margin-bottom: $spacing-unit / 2;
 }
 
 .post-title {


### PR DESCRIPTION
Added exchange fork pairs as table in fork page.
Also cleaned up redundant `repo` and `project_url` links into _layout file.

Preview: https://brinkt.github.io/chainsplit-www/
